### PR TITLE
[0827] feat: 회원가입 시 이용약관, 개인정보처리방침, 결제 및 환불 절차 동의 체크 추가

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -45,5 +45,5 @@ class SocialSignUpForm(forms.ModelForm):
     def clean_username(self):
         username = self.cleaned_data.get('username')
         if not re.match(r'^[a-zA-Z]+$', username):
-            raise forms.ValidationError("Username must contain only English letters.")
+            raise forms.ValidationError("사용자 이름은 영어로만 작성 가능합니다.")
         return username

--- a/accounts/templates/accounts/social_signup.html
+++ b/accounts/templates/accounts/social_signup.html
@@ -12,14 +12,12 @@
     <h1 class="logo">Social Signup</h1>
 
     {% if form_errors %}
-        <div class="form-errors">
-            <ul>
-                {% for field, errors in form_errors.items %}
-                    {% for error in errors %}
-                        <li>{{ field }}: {{ error }}</li>
-                    {% endfor %}
+        <div class="info-box-red">
+            {% for field, errors in form_errors.items %}
+                {% for error in errors %}
+                    <p>{{ field }}: {{ error }}</p>
                 {% endfor %}
-            </ul>
+            {% endfor %}
         </div>
     {% endif %}
     
@@ -39,10 +37,6 @@
                 </div>
             </div>
             <div class="signup-form-group">
-                <label for="{{ form.email_opt_in.id_for_label }}">Subscribe to Emails:</label>
-                {{ form.email_opt_in }}
-            </div>
-            <div class="signup-form-group">
                 <label>Birth Date:</label>
                 <div class="birthdate-fields">
                     {{ form.birth_year }} -
@@ -53,6 +47,29 @@
             <div class="signup-form-group">
                 <label for="{{ form.gender.id_for_label }}">Gender:</label>
                 {{ form.gender }}
+            </div>
+            
+            <hr style="margin: 20px 0;">  <!-- 여기에서 구분선 추가 -->
+            
+            <!-- 약관 동의 체크박스 추가 -->
+            <div class="signup-form-group">
+                <label>(필수) 개인정보처리방침 동의:</label>
+                <input type="checkbox" name="agree_privacy_policy" required>
+                <a href="{% url 'document_privacy_policy' %}" target="_blank" class="terms-link">약관보기</a>
+            </div>
+            <div class="signup-form-group">
+                <label>(필수) 이용약관 동의:</label>
+                <input type="checkbox" name="agree_terms_of_service" required>
+                <a href="{% url 'document_terms_of_service' %}" target="_blank" class="terms-link">약관보기</a>
+            </div>
+            <div class="signup-form-group">
+                <label>(필수) 결제 및 환불 절차 동의:</label>
+                <input type="checkbox" name="agree_payment_refund_policy" required>
+                <a href="{% url 'document_payment_refund_policy' %}" target="_blank" class="terms-link">약관보기</a>
+            </div>
+            <div class="signup-form-group">
+                <label for="{{ form.email_opt_in.id_for_label }}">(선택) 할인 및 이벤트 안내 이메일 수신 동의:</label>
+                {{ form.email_opt_in }}
             </div>
         </div>
         <div>

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -114,11 +114,21 @@ def social_signup(request):
         phone1 = request.POST.get('phone1')
         phone2 = request.POST.get('phone2')
 
-        # phone1 또는 phone2 필드가 비어 있거나 4자리가 아닌 경우
-        if not phone1 or not phone2 or len(phone1) != 4 or len(phone2) != 4:
+        if not phone1.isdigit() or not phone2.isdigit() or len(phone1) != 4 or len(phone2) != 4:
             return render(request, 'accounts/social_signup.html', {
                 'form': SocialSignUpForm(request.POST),
-                'form_errors': {'phone': ["전화번호를 올바르게 입력해 주세요. (각각 4자리 숫자)"]},
+                'form_errors': {'phone': ["전화번호를 올바르게 입력해 주세요. (각각 4자리 숫자만 입력해 주세요)"]},
+            })
+
+        # 약관 동의 체크 여부 확인
+        agree_privacy_policy = request.POST.get('agree_privacy_policy')
+        agree_terms_of_service = request.POST.get('agree_terms_of_service')
+        agree_payment_refund_policy = request.POST.get('agree_payment_refund_policy')
+
+        if not (agree_privacy_policy and agree_terms_of_service and agree_payment_refund_policy):
+            return render(request, 'accounts/social_signup.html', {
+                'form': SocialSignUpForm(request.POST),
+                'form_errors': {'terms': ["모든 필수 약관에 동의하셔야 가입이 가능합니다."]},
             })
 
         full_phone = f"010-{phone1}-{phone2}"
@@ -141,6 +151,7 @@ def social_signup(request):
     else:
         form = SocialSignUpForm()
     return render(request, 'accounts/social_signup.html', {'form': form})
+
 
 @login_required
 def profile_update(request):

--- a/static/css/account.css
+++ b/static/css/account.css
@@ -8,6 +8,13 @@
     padding-top: 20px;
 }
 
+.terms-link {
+    margin-left: 10px;
+    color: blue;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
 .social-login-form {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### PR 내용:

회원가입 시 사용자가 개인정보처리방침, 이용약관, 결제 및 환불 절차에 동의하도록 하는 기능을 추가하였음.

#### 주요 변경 사항:
1. **이용약관 및 동의 체크박스 추가**:
    - 회원가입 폼에 개인정보처리방침, 이용약관, 결제 및 환불 절차에 대한 동의 체크박스를 추가
    - 사용자는 모든 필수 약관에 동의해야만 회원가입이 가능하며, 동의하지 않으면 오류 메시지가 표시

2. **'약관보기' 링크 추가**:
    - 각 약관 옆에 '약관보기' 링크를 추가하여, 사용자가 해당 약관을 새 창에서 확인할 수 있도록 구현

3. **폼 및 유효성 검사**:
    - 사용자가 약관에 동의했는지를 확인하는 로직을 `views.py`에 추가하였으며, 약관 동의 여부에 따라 적절한 오류 메시지를 반환

#### 테스트:
- 회원가입 시 각 약관 동의 여부에 따른 유효성 검사가 정상적으로 동작하는지 확인함.
- '약관보기' 링크가 올바른 문서 페이지로 이동하는지 확인함.

