### PR TITLE
[0302] 타임존 오류 해결

### DIFF
--- a/locker/management/commands/reset_expiring_lockers.py
+++ b/locker/management/commands/reset_expiring_lockers.py
@@ -8,7 +8,7 @@ class Command(BaseCommand):
     help = '대여 종료 시간이 지난 LockerOrder의 상태를 업데이트하고, 관련 Locker를 사용가능 상태로 변경합니다.'
 
     def handle(self, *args, **options):
-        now = timezone.now()
+        now = timezone.localtime()
         expired_orders = LockerOrder.objects.filter(locker_status=LockerOrder.Status.INSERVICE)
         
         for order in expired_orders:

--- a/locker/management/commands/send_expiring_emails.py
+++ b/locker/management/commands/send_expiring_emails.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
     help = "서비스 만료 임박 주문 건에 대해 이메일 알림을 발송합니다."
 
     def handle(self, *args, **options):
-        now = timezone.now()
+        now = timezone.localtime()
         # locker_status가 INSERVICE인 주문들만 필터링
         orders = LockerOrder.objects.filter(locker_status=LockerOrder.Status.INSERVICE)
         emails_sent = 0


### PR DESCRIPTION
### PR Summary 🚀 - 2025.03.01

- **타임존 오류 해결**  
  - timezone.localtime()을 쓰느냐 timezone.now()를 쓰느냐에 따라 시간이 다르다는 것을 알게 되었음. -> timezone.now()는 UTC기반으로 시간을 반환하기에 스케줄러는 ec2에서 정상작동하는데 새벽중 와야했던 메일이 오지 않음, utc기반으로 계산되었기 때문
  - EC2 크론탭에서 매일 자정에 정상 실행될 수 있도록 timezone.localtime()으로 코드 변경하였음.

