### PR TITLE
[0412] feat: update middle bar -> 프리프린트 클라우드 바로가기 링크 생성

### DIFF
--- a/templates/print_main.html
+++ b/templates/print_main.html
@@ -20,6 +20,9 @@
         <a href="{% url 'locker:print_detail' %}" class="btn btn-primary btn-lg rounded-3 btn-same-width">
           사물함 예약
         </a>
+        <a href="https://preprintcloud.com" class="btn btn-primary btn-lg rounded-3 btn-same-width">
+          클라우드 서비스
+         </a>
         <form method="post" action="{% url 'logout' %}" class="d-inline-block">
           {% csrf_token %}
           <button type="submit" class="btn btn-primary btn-lg rounded-3 btn-same-width">
@@ -27,6 +30,9 @@
           </button>
         </form>
       {% else %}
+      <a href="https://preprintcloud.com" class="btn btn-primary btn-lg rounded-3 btn-same-width">
+        클라우드 서비스
+       </a>
         <a href="{% url 'login' %}" class="btn btn-primary btn-lg rounded-3 btn-same-width">
           로그인
         </a>


### PR DESCRIPTION
## PR Summary 🚀 - 2025.04.12

### 프리프린트 클라우드 서비스 바로가기 링크 생성
- 프리프린트 클라우드 서비스를 새로운 서버에 배포 세팅 완료함에 따라 기존 프리프린트 클라우드 서비스도 함께 이용할 수 있도록 예약서비스 중간 바에 바로가기 링크 추가

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/4e5eccc7-b71e-41a2-aedb-c781b276097c" />
=> 다음과 같음